### PR TITLE
Make systems not written as classes anymore

### DIFF
--- a/braga/examples/duel/__init__.py
+++ b/braga/examples/duel/__init__.py
@@ -8,9 +8,9 @@ from braga.examples.duel.duel import EquipmentBearing
 from braga.examples.duel.duel import Loyalty
 from braga.examples.duel.duel import ExpelliarmusSkill
 
-from braga.examples.duel.duel import ContainerSystem
-from braga.examples.duel.duel import EquipmentSystem
-from braga.examples.duel.duel import NameSystem
+from braga.examples.duel.duel import container_system
+from braga.examples.duel.duel import equipment_system
+# from braga.examples.duel.duel import NameSystem
 
 from braga.examples.duel.duel import player_factory
 from braga.examples.duel.duel import room_factory

--- a/braga/examples/duel/duel.py
+++ b/braga/examples/duel/duel.py
@@ -33,7 +33,8 @@ class Description(Component):
 
 class Container(Component):
     """Ability to have an inventory. For rooms and players."""
-    pass
+    def __init__(self, inventory=None):
+        self.inventory = inventory if inventory else set()
 
 
 class EquipmentBearing(Component):
@@ -88,67 +89,52 @@ class ExpelliarmusSkill(Component):
 #####################################
 # Define systems to manage components
 #####################################
-class ContainerSystem(System):
-    """Manages Containers and the Moveables they contain."""
-    def __init__(self, world, auto_update=False):
-        super(ContainerSystem, self).__init__(world=world, aspect=Aspect(all_of=set([Container])))
-        self.inventories = defaultdict(set)
-        self.auto_update = auto_update
-        for entity in self.world.entities_with_aspect(Aspect(all_of=set([Moveable]))):
-            self.inventories[entity.location].add(entity)
-        self.update()
 
-    def update(self):
-        """Updates the `inventory` attribute on all Containers in the World"""
-        for entity in self.world.entities_with_aspect(Aspect(all_of=set([Moveable]))):
-            self.inventories[entity.location].add(entity)
-        for entity in self.entities:
-            setattr(entity, 'inventory', self.inventories[entity])
-
-    def move(self, thing, new_container, auto_update=False):
-        """Moves a Moveable into a Container."""
-        if not thing.has_component(Moveable):
-            raise ValueError("You cannot move this item")
-        if not new_container in self.aspect:
-            raise ValueError("Invalid destination")
-        old_container = thing.location
-        thing.location = new_container
-        self.inventories[new_container].add(thing)
-        if old_container:
-            self.inventories[old_container].remove(thing)
-        self.update()
+container_system = System()
+equipment_system = System()
 
 
-class EquipmentSystem(System):
-    """Manager for Equipment and its bearers."""
-    def __init__(self, world, auto_update=False):
-        super(EquipmentSystem, self).__init__(world=world, aspect=Aspect(all_of=set([EquipmentBearing])))
-        self.equipment = defaultdict(lambda: None)
-        self.auto_update = auto_update
-        self.update()
+@container_system
+def move(thing, new_container):
+    if not thing.has_component(Moveable):
+        raise ValueError("You cannot move this item")
+    if not new_container.has_component(Container):
+        raise ValueError("Invalid destination")
+    old_container = thing.location
+    thing.location = new_container
+    if old_container:
+        old_container.inventory.remove(thing)
+    new_container.inventory.add(thing)
 
-    def equip(self, bearer, item, auto_update=False):
-        """Equip an Entity with another Entity"""
-        if not bearer in self:
-            raise ValueError("That cannot equip other items")
-        if not item in self.world.entities_with_aspect(Aspect(all_of=set([Equipment]))):
-            raise ValueError("That item cannot be equipped")
-        if self.equipment[bearer]:
-            raise ValueError("You cannot equip that at this time")
-        self.equipment[bearer] = item
-        self.update()
 
-    def unequip(self, bearer, item):
-        """Unequip an Entity from the Entity equipping it."""
-        del self.equipment[bearer]
-        delattr(bearer, item.equipment_type)
+@equipment_system
+def equip(bearer, item):
+    """Equip an Entity with another Entity"""
+    if not bearer.has_component(EquipmentBearing):
+        raise ValueError("That cannot equip other items")
+    if not item.has_component(Equipment):
+        raise ValueError("That item cannot be equipped")
 
-    def update(self):
-        for entity in self.entities:
-            item = self.equipment[entity]
-            if item:
-                setattr(entity, item.equipment_type, item)
-                item.bearer = entity
+    try:
+        equipped_item = getattr(bearer, item.equipment_type)
+    except AttributeError:
+        equipped_item = None
+
+    if equipped_item:
+        if equipped_item is item:
+            raise ValueError("You are already equipping that item")
+        else:
+            raise ValueError("You are already equipping an item of this type")
+
+    setattr(bearer, item.equipment_type, item)
+    item.bearer = bearer
+
+
+@equipment_system
+def unequip(bearer, item):
+    """Unequip an Entity from the Entity equipping it."""
+    delattr(bearer, item.equipment_type)
+    item.bearer = None
 
 
 class NameSystem(System):

--- a/braga/examples/duel/tests.py
+++ b/braga/examples/duel/tests.py
@@ -13,8 +13,6 @@ class TestEquipmentSystem(unittest.TestCase):
         self.wand_factory = Assemblage([duel.Equipment], equipment_type='wand')
         self.wand = self.world.make_entity(self.wand_factory)
 
-        self.equipment_system = duel.EquipmentSystem(world=self.world, auto_update=True)
-
     def test_player_has_no_equipment(self):
         self.assertFalse(hasattr(self.player, 'wand'))
 
@@ -22,12 +20,12 @@ class TestEquipmentSystem(unittest.TestCase):
         second_wand = self.world.make_entity(self.wand_factory)
 
         with self.assertRaises(ValueError) as e:
-            self.equipment_system.equip(self.wand, second_wand)
+            duel.equipment_system.equip(self.wand, second_wand)
 
         self.assertEqual(e.exception.message, "That cannot equip other items")
 
     def test_player_equips_an_item(self):
-        self.equipment_system.equip(self.player, self.wand)
+        duel.equipment_system.equip(self.player, self.wand)
 
         self.assertEqual(self.player.wand, self.wand)
 
@@ -35,29 +33,29 @@ class TestEquipmentSystem(unittest.TestCase):
         """ In other minigames, you will be allowed to equip an arbitrary number
             of items, but that is not necessary for the duel simulator.
         """
-        self.equipment_system.equip(self.player, self.wand)
+        duel.equipment_system.equip(self.player, self.wand)
 
         second_wand = self.world.make_entity(self.wand_factory)
 
         with self.assertRaises(ValueError) as e:
-            self.equipment_system.equip(self.player, second_wand)
+            duel.equipment_system.equip(self.player, second_wand)
 
-        self.assertEqual(e.exception.message, "You cannot equip that at this time")
+        self.assertEqual(e.exception.message, "You are already equipping an item of this type")
 
         self.assertEqual(self.player.wand, self.wand)
 
     def test_unequipping_an_item(self):
-        self.equipment_system.equip(self.player, self.wand)
-        self.equipment_system.unequip(self.player, self.wand)
+        duel.equipment_system.equip(self.player, self.wand)
+        duel.equipment_system.unequip(self.player, self.wand)
 
         self.assertFalse(hasattr(self.player, 'wand'))
 
     def test_unequipping_and_reequipping_an_item(self):
-        self.equipment_system.equip(self.player, self.wand)
-        self.equipment_system.unequip(self.player, self.wand)
+        duel.equipment_system.equip(self.player, self.wand)
+        duel.equipment_system.unequip(self.player, self.wand)
 
         second_wand = self.world.make_entity(self.wand_factory)
-        self.equipment_system.equip(self.player, second_wand)
+        duel.equipment_system.equip(self.player, second_wand)
 
         self.assertEqual(self.player.wand, second_wand)
 
@@ -72,11 +70,10 @@ class TestContainerSystem(unittest.TestCase):
 
         self.thing_factory = Assemblage(components=[duel.Moveable])
         self.thing = self.world.make_entity(self.thing_factory, location=self.bucket_one)
-
-        self.container_system = duel.ContainerSystem(world=self.world, auto_update=True)
+        self.bucket_one.inventory.add(self.thing)
 
     def test_move_item_to_new_inventory(self):
-        self.container_system.move(self.thing, self.bucket_two)
+        duel.container_system.move(self.thing, self.bucket_two)
 
         self.assertEqual(self.thing.location, self.bucket_two)
         self.assertEqual(self.bucket_two.inventory, set([self.thing]))
@@ -85,7 +82,7 @@ class TestContainerSystem(unittest.TestCase):
         bookcase = self.world.make_entity()
 
         with self.assertRaises(ValueError) as e:
-            self.container_system.move(bookcase, self.bucket_two)
+            duel.container_system.move(bookcase, self.bucket_two)
 
         self.assertEqual(e.exception.message, "You cannot move this item")
         self.assertEqual(self.bucket_two.inventory, set([]))
@@ -93,7 +90,7 @@ class TestContainerSystem(unittest.TestCase):
     def test_cannot_move_item_to_non_container(self):
         new_thing = self.thing_factory.make()
         with self.assertRaises(ValueError) as e:
-            self.container_system.move(self.thing, new_thing)
+            duel.container_system.move(self.thing, new_thing)
 
         self.assertEqual(e.exception.message, "Invalid destination")
         self.assertEqual(self.thing.location, self.bucket_one)

--- a/braga/system.py
+++ b/braga/system.py
@@ -1,16 +1,12 @@
-import abc
-from functools import wraps
-
-from braga.aspect import Aspect
+import functools
 
 
 def call_hooks(function):
-    @wraps(function)
+    @functools.wraps(function)
     def wrapper(*args, **kwargs):
-        run_hooks(args[0], function.__name__, 'before', *args, **kwargs)
+        run_hooks(function.system, function.__name__, 'before', *args, **kwargs)
         result = function(*args, **kwargs)
-        run_hooks(args[0], function.__name__, 'after', *args, **kwargs)
-
+        run_hooks(function.system, function.__name__, 'after', *args, **kwargs)
         return result
 
     wrapper.__wrapped__ = function
@@ -20,37 +16,19 @@ def call_hooks(function):
 class System(object):
     """Handler for modifying and updating Entities with a particular pattern of Components."""
 
-    __metaclass__ = abc.ABCMeta
+    def __init__(self, world=None):
+        if world:
+            self.world = world
 
-    def __init__(self, world, aspect=None):
-        self.world = world
-        self.aspect = aspect if aspect else Aspect()
-
-    def __new__(cls, *args, **kwargs):
-        for name, obj in vars(cls).items():
-            if callable(obj) and not name.startswith('_') and not hasattr(obj, '__wrapped__'):
-                try:
-                    obj = obj.__func__
-                except AttributeError:
-                    pass
-                setattr(cls, name, call_hooks(obj))
-        new_system = object.__new__(cls, *args, **kwargs)
-        return new_system
-
-    def __contains__(self, entity):
-        return entity in self.aspect
-
-    @property
-    def entities(self):
-        """Set of Entities in the World with this Aspect"""
-        return self.world.entities_with_aspect(self.aspect)
-
-    @abc.abstractmethod
-    def update(self):
-        """Updates the entities in this system"""
+    def __call__(self, func):
+        setattr(func, 'system', self)
+        wrapped_func = call_hooks(func)
+        setattr(self, func.__name__, wrapped_func)
+        return wrapped_func
 
 
 def run_hooks(system, function_name, position, *fn_args, **fn_kwargs):
-    callbacks = system.world.subscriptions[system][function_name][position]
-    for callback in callbacks:
-        callback(*fn_args, **fn_kwargs)
+    if hasattr(system, 'world'):
+        callbacks = system.world.subscriptions[system][function_name][position]
+        for callback in callbacks:
+            callback(*fn_args, **fn_kwargs)

--- a/braga/world.py
+++ b/braga/world.py
@@ -75,6 +75,9 @@ class World(object):
         return extra_output
 
     def subscribe(self, system, method, callback, before=False, after=False):
+        if not (before or after):
+            raise ValueError("You won't actually subscribe anything to anything unless you set before or after")
+
         if not hasattr(callback, '__call__'):
             raise TypeError("Only callables can be registered as preactions or reactions")
 

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,51 +1,55 @@
 import unittest
-from mock import Mock, patch
+from mock import patch
 
 from braga import System, World
 
 
-class BadSystem(System):
-    def __init__(self):
-        super(BadSystem, self).__init__(world=Mock())
-
-
-class GoodSystem(System):
-
-    def __init__(self, world):
-        super(GoodSystem, self).__init__(world=world)
-
-    def child_method(self, arg_one, kwarg_two=False):
-        pass
-
-    def update(self):
-        pass
-
-
-def before_child_method_runs(system, arg_one, kwarg_two=False):
+def before_child_method_runs(arg_one, kwarg_two=False):
     pass
 
 
-def after_child_method_runs(system, arg_one, kwarg_two=False):
+def after_child_method_runs(arg_one, kwarg_two=False):
     pass
 
 
 class TestSystem(unittest.TestCase):
 
-    def test_must_implement_update_method(self):
-        with self.assertRaises(TypeError):
-            BadSystem()
-
     def test_child_methods_are_decorated(self):
         world = World()
-        system = GoodSystem(world)
-        self.assertIn('run_hooks', system.child_method.__func__.func_code.co_names)
+        system = System(world)
+
+        @system
+        def child_method(arg_one, kwarg_two=False):
+            pass
+
+        self.assertIn('run_hooks', system.child_method.func_code.co_names)
 
     @patch('tests.test_system.before_child_method_runs')
     def test_child_methods_look_for_before_hooks(self, callback_mock):
         world = World()
-        system = GoodSystem(world)
+        system = System(world)
+
+        @system
+        def child_method(arg_one, kwarg_two=False):
+            pass
+
         world.subscribe(system, 'child_method', before_child_method_runs, before=True)
 
         system.child_method('first_arg', kwarg_two='keyword_arg')
 
-        callback_mock.assert_called_once_with(system, 'first_arg', kwarg_two='keyword_arg')
+        callback_mock.assert_called_once_with('first_arg', kwarg_two='keyword_arg')
+
+    @patch('tests.test_system.after_child_method_runs')
+    def test_child_methods_look_for_after_hooks(self, callback_mock):
+        world = World()
+        system = System(world)
+
+        @system
+        def child_method(arg_one, kwarg_two=False):
+            pass
+
+        world.subscribe(system, 'child_method', after_child_method_runs, after=True)
+
+        system.child_method('first_arg', kwarg_two='keyword_arg')
+
+        callback_mock.assert_called_once_with('first_arg', kwarg_two='keyword_arg')

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -4,18 +4,6 @@ from braga import World, Entity, Assemblage, System
 from tests.fixtures import Moveable, Location
 
 
-class SomeKindOfSystem(System):
-
-    def __init__(self, world):
-        super(SomeKindOfSystem, self).__init__(world=world)
-
-    def do_something(self, thing):
-        pass
-
-    def update(self):
-        pass
-
-
 class TestWorld(unittest.TestCase):
 
     def setUp(self):
@@ -64,6 +52,7 @@ class TestWorld(unittest.TestCase):
         self.assertEqual(e.exception.message, "{0} does not contain {1}".format(repr(self.world), repr(unrelated_entity)))
 
     def test_add_system_registers_system(self):
+        self.skipTest('Functionality soon to be removed')
         new_system = self.world.add_system(SomeKindOfSystem)
 
         self.assertTrue(isinstance(new_system, System))
@@ -71,12 +60,14 @@ class TestWorld(unittest.TestCase):
         self.assertEqual(new_system.world, self.world)
 
     def test_add_system_rejects_non_systems(self):
+        self.skipTest('Functionality soon to be removed')
         with self.assertRaises(ValueError) as e:
             self.world.add_system(Assemblage)
 
         self.assertEqual(e.exception.message, "{} is not a type of System".format(Assemblage.__name__))
 
     def test_add_system_rejects_duplicate_systems(self):
+        self.skipTest('Functionality soon to be removed')
         self.world.add_system(SomeKindOfSystem)
 
         with self.assertRaises(ValueError) as e:
@@ -91,17 +82,30 @@ class TestWorld(unittest.TestCase):
         def check_to_run_after_method(system, thing):
             pass
 
-        system = self.world.add_system(SomeKindOfSystem)
+        some_kind_of_system = System(self.world)
 
-        self.world.subscribe(system, 'do_something', check_to_run_before_method, before=True)
-        self.world.subscribe(system, 'do_something', check_to_run_after_method, after=True)
+        self.world.subscribe(some_kind_of_system, 'do_something', check_to_run_before_method, before=True)
+        self.world.subscribe(some_kind_of_system, 'do_something', check_to_run_after_method, after=True)
 
-        self.assertIn(check_to_run_before_method, self.world.subscriptions[system]['do_something']['before'])
-        self.assertIn(check_to_run_after_method, self.world.subscriptions[system]['do_something']['after'])
+        self.assertIn(check_to_run_before_method, self.world.subscriptions[some_kind_of_system]['do_something']['before'])
+        self.assertIn(check_to_run_after_method, self.world.subscriptions[some_kind_of_system]['do_something']['after'])
 
-    def test_cannot_subscribe_non_functions_to_systems(self):
-        system = self.world.add_system(SomeKindOfSystem)
+    def test_cannot_subscribe_non_callables_to_systems(self):
+        class Foo(object):
+            pass
 
-        for thing in ['string', [], {}, system]:
+        foo = Foo()
+        some_kind_of_system = System(self.world)
+
+        for thing in ['string', [], {}, foo]:
             with self.assertRaises(TypeError):
-                self.world.subscribe(system, 'do_something', thing)
+                self.world.subscribe(some_kind_of_system, 'do_something', thing, after=True)
+
+    def test_must_choose_a_time_for_callback_to_be_called(self):
+        def callback_method(*args):
+            pass
+
+        some_kind_of_system = System(self.world)
+
+        with self.assertRaises(ValueError):
+            self.world.subscribe(some_kind_of_system, 'do_something', callback_method)


### PR DESCRIPTION
Refactor Systems to make them more Pythonic. Basically, a System as a class that required instantiation when it doesn't really need to hold state is a very Java-like pattern that doesn't belong in Python. This code allows System methods to be written as top-level functions. I do tie them together with an object because _eventually_ this framework should be able to support multiplayer games and I'll need threads and each system should run on a separate thread so they still need to be connected somehow. Also I like the namespacing.