### PR TITLE
Replace INITIAL_PROPERTIES with __slots__

### DIFF
--- a/braga/assemblage.py
+++ b/braga/assemblage.py
@@ -17,9 +17,9 @@ class Assemblage(object):
         self.component_types = defaultdict(dict)
         for component in components:
             self.component_types[component].update(
-                {k:v for k,v in six.iteritems(kwargs) if k in component.INITIAL_PROPERTIES}
+                {k:v for k,v in six.iteritems(kwargs) if k in component.__slots__}
             )
-            kwargs = {k:v for k,v in six.iteritems(kwargs) if k not in component.INITIAL_PROPERTIES}
+            kwargs = {k:v for k,v in six.iteritems(kwargs) if k not in component.__slots__}
 
     def add_component(self, component_type, **kwargs):
         """Adds a component type to the factory."""
@@ -41,8 +41,8 @@ class Assemblage(object):
 
         for component_type, init_kwargs in six.iteritems(self.component_types):
             instance_kwargs = init_kwargs
-            instance_kwargs.update({k:v for k,v in six.iteritems(kwargs) if k in component_type.INITIAL_PROPERTIES})
-            kwargs = {k:v for k,v in six.iteritems(kwargs) if k not in component_type.INITIAL_PROPERTIES}
+            instance_kwargs.update({k:v for k,v in six.iteritems(kwargs) if k in component_type.__slots__})
+            kwargs = {k:v for k,v in six.iteritems(kwargs) if k not in component_type.__slots__}
 
             component = component_type(**instance_kwargs)
             entity.components.add(component)

--- a/braga/component.py
+++ b/braga/component.py
@@ -1,7 +1,7 @@
 class Component(object):
     """Base class to be inherited by user-defined Component types."""
 
-    INITIAL_PROPERTIES = []
+    __slots__ = []
 
     def __repr__(self):
         return type(self).__name__

--- a/braga/examples/duel/duel.py
+++ b/braga/examples/duel/duel.py
@@ -13,7 +13,7 @@ from braga import Assemblage, Component, System, Aspect
 class Name(Component):
     """A name for the Entity. For players and wands."""
 
-    INITIAL_PROPERTIES = ['name']
+    __slots__ = ['name']
 
     def __init__(self, name=None):
         self.name = name
@@ -22,11 +22,10 @@ class Name(Component):
 class Description(Component):
     """A description of the Entity. For all entities."""
 
-    INITIAL_PROPERTIES = ['description']
+    __slots__ = ['description']
 
     def __init__(self, description=None):
         self.description = description
-        self.description_tags = self.get_tags()
 
     def get_tags(self):
         full_path_tags = set([tag for text, tag, spec, conv in string.Formatter().parse(self.description) if tag is not None])
@@ -35,6 +34,9 @@ class Description(Component):
 
 class Container(Component):
     """Ability to have an inventory. For rooms and players."""
+
+    __slots__ = ['inventory']
+
     def __init__(self, inventory=None):
         self.inventory = inventory if inventory else set()
 
@@ -49,6 +51,8 @@ class Mappable(Component):
         For rooms only.
     """
 
+    __slots__ = ['paths']
+
     def __init__(self, paths=None):
         self.paths = paths if paths else dict()
 
@@ -56,7 +60,7 @@ class Mappable(Component):
 class Moveable(Component):
     """Ability to be moved, stores Entity's location. For players and wands."""
 
-    INITIAL_PROPERTIES = ['location']
+    __slots__ = ['location']
 
     def __init__(self, location=None):
         self.location = location
@@ -65,7 +69,7 @@ class Moveable(Component):
 class Equipment(Component):
     """Ability to be equipped. Stores what type of equipment the Entity is. For wands."""
 
-    INITIAL_PROPERTIES = ['equipment_type', 'bearer']
+    __slots__ = ['equipment_type', 'bearer']
 
     def __init__(self, equipment_type, bearer=None):
         self.equipment_type = equipment_type
@@ -75,7 +79,7 @@ class Equipment(Component):
 class Loyalty(Component):
     """Tracks what other Entity this Entity is loyal / belongs to. For wands."""
 
-    INITIAL_PROPERTIES = ['owner']
+    __slots__ = ['owner']
 
     def __init__(self, owner=None):
         self.owner = owner
@@ -83,6 +87,8 @@ class Loyalty(Component):
 
 class ExpelliarmusSkill(Component):
     """Ability to cast expelliarmus, stores skill at casting expelliarmus. For players."""
+
+    __slots__ = ['skill']
 
     def __init__(self):
         self.skill = 0

--- a/braga/manager.py
+++ b/braga/manager.py
@@ -9,7 +9,7 @@ class Manager(object):
         self.entities_by_component = dict()
 
         if not properties_to_register:
-            properties_to_register = self.component_type.INITIAL_PROPERTIES
+            properties_to_register = self.component_type.__slots__
         self.properties_to_register = properties_to_register
 
         for prop in self.properties_to_register:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -3,20 +3,16 @@ from braga import Component
 
 class Alive(Component):
 
-    INITIAL_PROPERTIES = ['alive']
+    __slots__ = ['alive']
 
     def __init__(self, alive=True):
-        self._alive = alive
-
-    @property
-    def alive(self):
-        return self._alive
+        self.alive = alive
 
     def die(self):
-        self._alive = False
+        self.alive = False
 
     def resurrect(self):
-        self._alive = True
+        self.alive = True
 
 
 class Portable(Component):
@@ -28,28 +24,24 @@ class Portable(Component):
 
 class Container(Component):
 
-    INITIAL_PROPERTIES = ['inventory']
+    __slots__ = ['inventory']
 
     def __init__(self, inventory=None):
-        self._inventory = set()
+        self.inventory = set()
         if inventory:
-            self._inventory |= inventory
-
-    @property
-    def inventory(self):
-        return self._inventory
+            self.inventory |= inventory
 
     def pick_up(self, thing):
         if hasattr(thing, 'is_portable'):
-            self._inventory.add(thing)
+            self.inventory.add(thing)
 
     def put_down(self, thing):
-        self._inventory.remove(thing)
+        self.inventory.remove(thing)
 
 
 class Moveable(Component):
 
-    INITIAL_PROPERTIES = ['v_x', 'v_y']
+    __slots__ = ['v_x', 'v_y']
 
     def __init__(self, v_x=0, v_y=0):
         self.v_x = v_x
@@ -58,7 +50,7 @@ class Moveable(Component):
 
 class Location(Component):
 
-    INITIAL_PROPERTIES = ['x', 'y']
+    __slots__ = ['x', 'y']
 
     def __init__(self, x=0, y=0):
         self.x = x

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -8,7 +8,7 @@ from braga import Component, Manager, Assemblage
 
 class ComponentWithState(Component):
 
-    INITIAL_PROPERTIES = ['number', 'letter']
+    __slots__ = ['number', 'letter']
 
     def __init__(self, number=None, letter=None):
         self.number = number


### PR DESCRIPTION
INITIAL_PROPERTIES is like a homegrown __slots__.

The difference is that __slots__ will prevent new properties from being added to components. I currently don't think that's terrible, although I may well have a game concept in a few month's time that requires adding arbitrary properties to components.